### PR TITLE
Wrap sys headers in extern C

### DIFF
--- a/sys/include/block.h
+++ b/sys/include/block.h
@@ -12,10 +12,16 @@ struct block {
     bool bootable;
 };
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 int
 block_add(struct block *block);
 
 struct block *
 block_find(bool (*predicate)(struct block *));
 
+#ifdef __cplusplus
+}
+#endif
 #endif

--- a/sys/include/buddy.h
+++ b/sys/include/buddy.h
@@ -31,6 +31,9 @@ struct buddy_allocator {
     size_t mem_available;
 };
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 /**
  * @brief   Initialize a buddy allocator
  *
@@ -60,4 +63,7 @@ buddy_allocator_malloc(struct buddy_allocator *allocator, unsigned int order);
 void
 buddy_allocator_free(struct buddy_allocator *allocator, void *addr);
 
+#ifdef __cplusplus
+}
+#endif
 #endif

--- a/sys/include/buffered_reader.h
+++ b/sys/include/buffered_reader.h
@@ -8,6 +8,9 @@ struct block_buffered_reader {
     unsigned int offset;
 };
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 void
 block_buffered_reader_init(
     struct block_buffered_reader *reader, struct block *block);
@@ -20,4 +23,7 @@ int
 block_buffered_reader_read(
     struct block_buffered_reader *reader, char *out, unsigned int count);
 
+#ifdef __cplusplus
+}
+#endif
 #endif

--- a/sys/include/bus.h
+++ b/sys/include/bus.h
@@ -23,6 +23,9 @@ struct bus {
     struct list_item *devices;
 };
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 int
 bus_init();
 
@@ -35,4 +38,7 @@ bus_match();
 int
 bus_probe();
 
+#ifdef __cplusplus
+}
+#endif
 #endif

--- a/sys/include/cpu.h
+++ b/sys/include/cpu.h
@@ -1,7 +1,13 @@
 #ifndef CPU_H
 #define CPU_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 int
 cpu_init();
 
+#ifdef __cplusplus
+}
+#endif
 #endif

--- a/sys/include/dev/input_device.h
+++ b/sys/include/dev/input_device.h
@@ -18,6 +18,9 @@ struct device_driver;
 struct input_device;
 struct input_event;
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 typedef uint8_t input_device_type_t;
 typedef uint8_t input_event_type_t;
 typedef uint8_t input_device_button_state_t;
@@ -75,4 +78,7 @@ input_device_find(const char *name);
 int
 input_device_event(struct input_device *idev, struct input_event event);
 
+#ifdef __cplusplus
+}
+#endif
 #endif

--- a/sys/include/dev/keycode.h
+++ b/sys/include/dev/keycode.h
@@ -111,7 +111,13 @@ enum {
     KEYCODE_NP_PERIOD
 };
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 char
 keycode_to_ascii(unsigned int keycode, bool shift_enabled);
 
+#ifdef __cplusplus
+}
+#endif
 #endif

--- a/sys/include/dev/platform_device.h
+++ b/sys/include/dev/platform_device.h
@@ -20,6 +20,9 @@ struct platform_device {
     struct list_item *resources;
 };
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 int
 platform_bus_init();
 
@@ -41,4 +44,7 @@ platform_device_register(struct platform_device *pdev);
 struct platform_device *
 platform_device_find(const char *name);
 
+#ifdef __cplusplus
+}
+#endif
 #endif

--- a/sys/include/device.h
+++ b/sys/include/device.h
@@ -15,7 +15,13 @@ struct device {
     struct device_driver *driver;
 };
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 int
 make_device(struct device *dev, const char *name);
 
+#ifdef __cplusplus
+}
+#endif
 #endif

--- a/sys/include/disk.h
+++ b/sys/include/disk.h
@@ -19,7 +19,13 @@ struct disk {
         struct device *dev, unsigned int lba, const char *buf, size_t count);
 };
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 int
 disk_register(struct disk *disk);
 
+#ifdef __cplusplus
+}
+#endif
 #endif

--- a/sys/include/driver.h
+++ b/sys/include/driver.h
@@ -25,6 +25,9 @@ struct file_operations {
     int (*seek)(struct device *dev, size_t offset, file_seek_mode_t seek_mode);
 };
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 int
 driver_init();
 
@@ -37,4 +40,7 @@ driver_find(const char *name);
 struct device_driver *
 driver_find_next(const struct device_driver *driver);
 
+#ifdef __cplusplus
+}
+#endif
 #endif

--- a/sys/include/driver/platform/ata.h
+++ b/sys/include/driver/platform/ata.h
@@ -48,6 +48,9 @@ struct ata_private {
     unsigned int drive_no;
 };
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 int
 ata_drv_init();
 
@@ -64,4 +67,7 @@ int
 ata_write_sectors(
     struct device *dev, unsigned int lba, const char *buf, size_t count);
 
+#ifdef __cplusplus
+}
+#endif
 #endif

--- a/sys/include/driver/platform/console.h
+++ b/sys/include/driver/platform/console.h
@@ -29,6 +29,9 @@ struct console_private {
     bool capslock_enabled;
 };
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 int
 console_drv_init();
 
@@ -44,4 +47,7 @@ console_read(struct device *dev, size_t offset, char *buf, size_t count);
 void
 console_clear_screen(struct device *dev);
 
+#ifdef __cplusplus
+}
+#endif
 #endif

--- a/sys/include/driver/platform/devfs.h
+++ b/sys/include/driver/platform/devfs.h
@@ -6,6 +6,9 @@
 struct device;
 struct platform_device;
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 int
 devfs_drv_init();
 
@@ -16,4 +19,7 @@ int
 devfs_read_sectors(
     struct device *dev, unsigned int lba, char *buf, size_t count);
 
+#ifdef __cplusplus
+}
+#endif
 #endif

--- a/sys/include/driver/platform/kbd.h
+++ b/sys/include/driver/platform/kbd.h
@@ -15,6 +15,9 @@ struct kbd_private {
     struct input_device *idev;
 };
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 int
 kbd_drv_init();
 
@@ -24,4 +27,7 @@ kbd_probe(struct platform_device *dev);
 int
 kbd_read(struct device *dev, char *buf, size_t len);
 
+#ifdef __cplusplus
+}
+#endif
 #endif

--- a/sys/include/driver/platform/kbd/ps2.h
+++ b/sys/include/driver/platform/kbd/ps2.h
@@ -38,6 +38,9 @@ enum ps2_port { PS2_PORT1 = 1, PS2_PORT2 = 2 };
 
 typedef enum ps2_port ps2_port_t;
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 void
 ps2_write_cmd(uint8_t cmd);
 
@@ -47,4 +50,7 @@ ps2_write_data(uint8_t data);
 uint8_t
 ps2_read_data();
 
+#ifdef __cplusplus
+}
+#endif
 #endif

--- a/sys/include/driver/platform/vga.h
+++ b/sys/include/driver/platform/vga.h
@@ -36,6 +36,9 @@ struct vga_private {
     uint8_t cur_char_color;
 };
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 int
 vga_drv_init();
 
@@ -69,4 +72,7 @@ vga_disable_cursor();
 void
 vga_set_cursor(struct device *dev, uint16_t row, uint16_t col);
 
+#ifdef __cplusplus
+}
+#endif
 #endif

--- a/sys/include/driver/platform_driver.h
+++ b/sys/include/driver/platform_driver.h
@@ -13,10 +13,16 @@ struct platform_driver {
     int (*probe)(struct platform_device *dev);
 };
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 int
 platform_driver_init();
 
 int
 platform_driver_register(struct platform_driver *driver);
 
+#ifdef __cplusplus
+}
+#endif
 #endif

--- a/sys/include/elf.h
+++ b/sys/include/elf.h
@@ -96,6 +96,9 @@ struct elf32_shdr {
     elf32_word sh_entsize;   /* Section table entry size */
 } __attribute__((packed));
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 /**
  * @brief Validate the ELF header signature
  *
@@ -150,4 +153,7 @@ elf32_is_exec(struct elf32_ehdr *ehdr);
 int
 elf32_is_valid(struct elf32_ehdr *ehdr);
 
+#ifdef __cplusplus
+}
+#endif
 #endif

--- a/sys/include/fd.h
+++ b/sys/include/fd.h
@@ -3,6 +3,9 @@
 
 struct process;
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 /**
  * @brief   Add a global file descriptor to the process
  *
@@ -33,4 +36,7 @@ process_get_gfd(struct process *process, int pfd);
 int
 process_remove_pfd(struct process *process, int pfd);
 
+#ifdef __cplusplus
+}
+#endif
 #endif

--- a/sys/include/file_descriptor.h
+++ b/sys/include/file_descriptor.h
@@ -32,6 +32,9 @@ struct dir_entry {
     char name[256];
 };
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 /**
  * @brief Retrieve a file descriptor
  *
@@ -58,4 +61,7 @@ file_descriptor_get_new(struct file_descriptor **desc_out);
 void
 file_descriptor_free(struct file_descriptor *descriptor);
 
+#ifdef __cplusplus
+}
+#endif
 #endif

--- a/sys/include/fs.h
+++ b/sys/include/fs.h
@@ -82,6 +82,9 @@ struct filesystem {
     char name[FILESYSTEM_NAME_MAX_LEN];
 };
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 /**
  * @brief Initialize the fileystem subsystem
  *
@@ -108,4 +111,7 @@ fs_resolve(struct mountpoint *mountpoint);
 file_mode_t
 fs_get_mode_from_string(const char *str);
 
+#ifdef __cplusplus
+}
+#endif
 #endif

--- a/sys/include/fs/devfs.h
+++ b/sys/include/fs/devfs.h
@@ -5,6 +5,9 @@ struct device;
 struct file_operations;
 struct filesystem;
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 /**
  * @brief Initialize a devfs filesystem
  *
@@ -23,4 +26,7 @@ devfs_init();
 int
 devfs_make_node(struct device *device, struct file_operations *fops);
 
+#ifdef __cplusplus
+}
+#endif
 #endif

--- a/sys/include/fs/ext2.h
+++ b/sys/include/fs/ext2.h
@@ -3,6 +3,9 @@
 
 struct filesystem;
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 /**
  * @brief Initialize an Ext2 filesystem
  *
@@ -11,4 +14,7 @@ struct filesystem;
 struct filesystem *
 ext2_init();
 
+#ifdef __cplusplus
+}
+#endif
 #endif

--- a/sys/include/fs/ext2/block_iter.h
+++ b/sys/include/fs/ext2/block_iter.h
@@ -37,6 +37,9 @@ struct ext2_block_iterator {
     uint32_t *tpl_indirect_blocks;
 };
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 /**
  * @brief Initialize a block iterator
  *
@@ -81,4 +84,7 @@ ext2_block_iterator_next(
 int
 ext2_block_iterator_block_no(struct ext2_block_iterator *iter);
 
+#ifdef __cplusplus
+}
+#endif
 #endif

--- a/sys/include/fs/ext2/dir.h
+++ b/sys/include/fs/ext2/dir.h
@@ -8,6 +8,9 @@ struct ext2_inode;
 struct ext2_private;
 struct ext2_dir_iter;
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 /**
  * @brief Find an entry in a directory
  *
@@ -28,4 +31,7 @@ ext2_dir_next_entry(
     struct ext2_private *fs_private, const struct ext2_inode *dir_inode,
     struct ext2_dir_iter *dir_iter, struct dir_entry *dir_entry_out);
 
+#ifdef __cplusplus
+}
+#endif
 #endif

--- a/sys/include/fs/ext2/dir_iter.h
+++ b/sys/include/fs/ext2/dir_iter.h
@@ -29,6 +29,9 @@ struct ext2_dir_iter {
     uint32_t block_offset;
 };
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 /**
  * @brief Initialze a directory iterator
  *
@@ -63,4 +66,7 @@ ext2_dir_iter_next(
     struct ext2_dir_iter *iter, struct ext2_private *fs_private,
     struct ext2_directory_entry *dir_entry_out);
 
+#ifdef __cplusplus
+}
+#endif
 #endif

--- a/sys/include/fs/ext2/inode.h
+++ b/sys/include/fs/ext2/inode.h
@@ -7,6 +7,9 @@
 
 struct disk;
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 /**
  * @brief Read an inode structure
  *
@@ -36,4 +39,7 @@ ext2_read_inode_data(
     struct ext2_private *fs_private, const struct ext2_inode *inode, char *out,
     size_t count, unsigned int blk_offset, unsigned int byte_offset);
 
+#ifdef __cplusplus
+}
+#endif
 #endif

--- a/sys/include/fs/fat32.h
+++ b/sys/include/fs/fat32.h
@@ -3,7 +3,13 @@
 
 #include "fs.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 struct filesystem *
 fat32_init();
 
+#ifdef __cplusplus
+}
+#endif
 #endif

--- a/sys/include/gdt.h
+++ b/sys/include/gdt.h
@@ -28,6 +28,9 @@ struct gdt {
     uint8_t base_24_31;
 } __attribute__((packed));
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 /**
  * @brief Initialize the Global Descriptor Table
  *
@@ -48,4 +51,8 @@ gdt_set_kernel_data_segment();
  */
 void
 gdt_set_user_data_segment();
+
+#ifdef __cplusplus
+}
+#endif
 #endif

--- a/sys/include/idt.h
+++ b/sys/include/idt.h
@@ -36,6 +36,9 @@ struct idt_entry {
     uint16_t offset2;
 } __attribute__((packed));
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 /**
  * @brief Initialize the Interrupt Descriptor Table
  *
@@ -43,4 +46,7 @@ struct idt_entry {
 void
 idt_init();
 
+#ifdef __cplusplus
+}
+#endif
 #endif

--- a/sys/include/irq.h
+++ b/sys/include/irq.h
@@ -3,6 +3,9 @@
 
 #include <stdint.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 /**
  * @brief Intialize the IRQ subsystem
  *
@@ -49,4 +52,7 @@ enable_interrupts();
 void
 disable_interrupts();
 
+#ifdef __cplusplus
+}
+#endif
 #endif

--- a/sys/include/kalloc.h
+++ b/sys/include/kalloc.h
@@ -13,6 +13,9 @@
 #define kalloc_order_to_size(order) (BUDDY_BLOCK_MIN_SIZE * (1 << order))
 #define kalloc_get_phys_page()      (kalloc_get_phys_pages(PHYS_PAGE_ORDER))
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 /**
  * @brief Initialize physical memory allocator
  *
@@ -77,4 +80,7 @@ kalloc_get_next_contiguous_allocation(void *paddr);
 int
 kalloc_size_to_order(size_t size);
 
+#ifdef __cplusplus
+}
+#endif
 #endif

--- a/sys/include/kernel.h
+++ b/sys/include/kernel.h
@@ -5,10 +5,16 @@
 
 #define KALLOC_PADDR_START ((void *)0x4400000) // 68MB
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 void
 panic(const char *str);
 
 void
 switch_to_kernel_vm_area();
 
+#ifdef __cplusplus
+}
+#endif
 #endif

--- a/sys/include/ld.h
+++ b/sys/include/ld.h
@@ -30,6 +30,9 @@ struct elf_img_desc {
 struct process;
 struct vm_area;
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 /**
  * @brief Initialize an ELF image from a file
  *
@@ -57,4 +60,7 @@ ld_free_image(struct elf_img_desc *img_desc);
 int
 ld_map_image_to_process(struct process *process);
 
+#ifdef __cplusplus
+}
+#endif
 #endif

--- a/sys/include/libk/alloc.h
+++ b/sys/include/libk/alloc.h
@@ -3,6 +3,9 @@
 
 #include <stddef.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 /**
  * @brief   Initialize the libk allocators
  *
@@ -68,4 +71,7 @@ kzalloc(size_t size);
 void
 kfree(void *ptr);
 
+#ifdef __cplusplus
+}
+#endif
 #endif

--- a/sys/include/libk/list.h
+++ b/sys/include/libk/list.h
@@ -14,6 +14,9 @@ struct list_item {
     struct list_item *next;
 };
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 /**
  * @brief   Add an item to the front of list
  *
@@ -92,4 +95,7 @@ list_empty(struct list_item *head);
 void
 list_destroy(struct list_item *head);
 
+#ifdef __cplusplus
+}
+#endif
 #endif

--- a/sys/include/libk/memory.h
+++ b/sys/include/libk/memory.h
@@ -3,6 +3,9 @@
 
 #include <stddef.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 int
 memcmp(const void *ptr1, const void *ptr2, size_t n);
 
@@ -12,4 +15,7 @@ memcpy(void *dest, const void *src, size_t n);
 void *
 memset(void *dest, int ch, size_t n);
 
+#ifdef __cplusplus
+}
+#endif
 #endif

--- a/sys/include/libk/print.h
+++ b/sys/include/libk/print.h
@@ -3,6 +3,9 @@
 
 #include <stdarg.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 /**
  * @brief Write a formatted string to a buffer
  *
@@ -35,4 +38,7 @@ sprintk(char *buf, const char *fmt, ...);
 int
 printk(const char *fmt, ...);
 
+#ifdef __cplusplus
+}
+#endif
 #endif

--- a/sys/include/libk/queue.h
+++ b/sys/include/libk/queue.h
@@ -11,6 +11,9 @@ struct queue {
     struct _queue_item *tail;
 };
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 int
 queue_enqueue(struct queue *queue, void *data);
 
@@ -23,4 +26,7 @@ queue_remove(struct queue *queue, void *data);
 void
 queue_destroy(struct queue *queue);
 
+#ifdef __cplusplus
+}
+#endif
 #endif

--- a/sys/include/libk/slab.h
+++ b/sys/include/libk/slab.h
@@ -34,6 +34,9 @@ struct slab_cache {
     struct slab *slab_head;
 };
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 /**
  * @brief   Create a new slab cache
  *
@@ -70,4 +73,7 @@ slab_cache_alloc(struct slab_cache *cache);
 int
 slab_cache_free(struct slab_cache *cache, void *ptr);
 
+#ifdef __cplusplus
+}
+#endif
 #endif

--- a/sys/include/libk/string.h
+++ b/sys/include/libk/string.h
@@ -4,6 +4,9 @@
 #include <stdbool.h>
 #include <stddef.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 char *
 strcat(char *dest, const char *src);
 
@@ -49,4 +52,7 @@ toupper(char c);
 char
 tolower(char c);
 
+#ifdef __cplusplus
+}
+#endif
 #endif

--- a/sys/include/mmap.h
+++ b/sys/include/mmap.h
@@ -5,6 +5,9 @@
 
 #include <stddef.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 void *
 process_mmap(
     struct process *process, void *addr, size_t length, int prot, int flags,
@@ -13,4 +16,7 @@ process_mmap(
 int
 process_munmap(struct process *process, void *addr, size_t length);
 
+#ifdef __cplusplus
+}
+#endif
 #endif

--- a/sys/include/mountpoint.h
+++ b/sys/include/mountpoint.h
@@ -24,6 +24,9 @@ struct mountpoint {
     char path[LATTE_MAX_PATH_LEN];
 };
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 /**
  * @brief Add a mountpoint
  *
@@ -42,4 +45,7 @@ mountpoint_add(struct mountpoint *mountpoint);
 struct mountpoint *
 mountpoint_find(const char *filename);
 
+#ifdef __cplusplus
+}
+#endif
 #endif

--- a/sys/include/msgbuf.h
+++ b/sys/include/msgbuf.h
@@ -1,6 +1,9 @@
 #ifndef MSGBUF_H
 #define MSGBUF_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 /**
  * @brief Write a message to the kernel message buffer
  *
@@ -22,4 +25,7 @@ msgbuf_add_output_fd(int fd);
 int
 msgbuf_flush();
 
+#ifdef __cplusplus
+}
+#endif
 #endif

--- a/sys/include/multiboot2.h
+++ b/sys/include/multiboot2.h
@@ -366,10 +366,16 @@ struct multiboot2_tag_load_base_addr {
     uint32_t load_base_addr;
 } __attribute__((packed));
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 int
 multiboot2_verify_magic_number(unsigned long magic);
 
 int
 multiboot2_get_boot_device(void *addr, uint32_t *biosdev, uint32_t *part_no);
 
+#ifdef __cplusplus
+}
+#endif
 #endif

--- a/sys/include/paging.h
+++ b/sys/include/paging.h
@@ -28,6 +28,9 @@
 
 #define is_aligned(addr) (((uint32_t)addr % PAGING_PAGE_SIZE) == 0)
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 /**
  * @brief Enable paging
  *
@@ -85,4 +88,7 @@ void *
 paging_find_free_extent(
     page_dir_t page_dir, void *base_vaddr, size_t num_pages);
 
+#ifdef __cplusplus
+}
+#endif
 #endif

--- a/sys/include/paging/page_dir.h
+++ b/sys/include/paging/page_dir.h
@@ -11,6 +11,9 @@ typedef uint32_t page_dir_entry_t;
 #define page_dir_starting_addr(page_dir)                                       \
     ((void *)((uint32_t)page_dir & 0xfffff000))
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 /**
  * @brief Retrieve a page directory entry from a page directory
  *
@@ -43,4 +46,7 @@ page_dir_entry_t
 page_dir_add_page_tbl(
     page_dir_t page_dir, void *vaddr, page_tbl_t page_tbl, uint8_t flags);
 
+#ifdef __cplusplus
+}
+#endif
 #endif

--- a/sys/include/paging/page_tbl.h
+++ b/sys/include/paging/page_tbl.h
@@ -11,6 +11,9 @@ typedef uint32_t page_tbl_entry_t;
 #define page_tbl_starting_addr(page_tbl)                                       \
     ((void *)((uint32_t)page_tbl & 0xfffff000))
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 /**
  * @brief Retrieve a page table entry from a page table
  *
@@ -32,4 +35,7 @@ void
 page_tbl_set_entry(
     page_tbl_t page_tbl, void *vaddr, page_tbl_entry_t page_tbl_entry);
 
+#ifdef __cplusplus
+}
+#endif
 #endif

--- a/sys/include/partition.h
+++ b/sys/include/partition.h
@@ -22,8 +22,14 @@ struct partition_table_entry {
     uint32_t sector_count;
 } __attribute__((packed));
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 int
 partition_read_partition_table(
     struct disk *disk, struct partition_table_entry *partition_table);
 
+#ifdef __cplusplus
+}
+#endif
 #endif

--- a/sys/include/path.h
+++ b/sys/include/path.h
@@ -34,6 +34,9 @@ struct path {
     struct path_element *root;
 };
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 /**
  * @brief Make a path from a path string
  *
@@ -52,4 +55,7 @@ path_from_str(struct path **path_out, const char *path_str);
 void
 path_free(struct path *path);
 
+#ifdef __cplusplus
+}
+#endif
 #endif

--- a/sys/include/port.h
+++ b/sys/include/port.h
@@ -1,6 +1,9 @@
 #ifndef CPU_PORT_H
 #define CPU_PORT_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 /**
  * @brief Read byte from io port
  *
@@ -37,4 +40,7 @@ outb(unsigned short port, unsigned char val);
 void
 outw(unsigned short port, unsigned short val);
 
+#ifdef __cplusplus
+}
+#endif
 #endif

--- a/sys/include/proc/exec.h
+++ b/sys/include/proc/exec.h
@@ -5,6 +5,9 @@
 
 struct process;
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 /**
  * @brief   Execute a new program.
  *
@@ -19,4 +22,7 @@ process_execv(
     struct process *process, const char *path, const char *const *argv,
     size_t argv_len);
 
+#ifdef __cplusplus
+}
+#endif
 #endif

--- a/sys/include/proc/exit.h
+++ b/sys/include/proc/exit.h
@@ -5,6 +5,9 @@
 
 struct process;
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 /**
  * @brief   Terminate a running process
  *
@@ -15,4 +18,7 @@ struct process;
 int
 process_exit(struct process *process, uint8_t status_code);
 
+#ifdef __cplusplus
+}
+#endif
 #endif

--- a/sys/include/proc/fork.h
+++ b/sys/include/proc/fork.h
@@ -3,6 +3,9 @@
 
 struct process;
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 /**
  * @brief   Fork a new process.
  *
@@ -13,4 +16,7 @@ struct process;
 int
 process_fork(struct process *parent, struct process **child);
 
+#ifdef __cplusplus
+}
+#endif
 #endif

--- a/sys/include/proc/wait.h
+++ b/sys/include/proc/wait.h
@@ -3,6 +3,9 @@
 
 #include "process.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 /**
  * @brief   Wait for a process to exit.
  *
@@ -13,4 +16,7 @@
 pid_t
 process_wait(struct process *process, int *status);
 
+#ifdef __cplusplus
+}
+#endif
 #endif

--- a/sys/include/process.h
+++ b/sys/include/process.h
@@ -106,6 +106,9 @@ struct process {
     struct list_item *open_fds;
 };
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 /**
  * @brief Get the next pid
  *
@@ -217,4 +220,7 @@ process_remove(struct process *process);
 void
 process_switch_to_vm_area(struct process *process);
 
+#ifdef __cplusplus
+}
+#endif
 #endif

--- a/sys/include/sched.h
+++ b/sys/include/sched.h
@@ -3,6 +3,9 @@
 
 struct thread;
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 /**
  * @brief Add a thread to the scheduler
  *
@@ -61,4 +64,7 @@ schedule_first_thread();
 void
 schedule();
 
+#ifdef __cplusplus
+}
+#endif
 #endif

--- a/sys/include/syscall.h
+++ b/sys/include/syscall.h
@@ -1,6 +1,9 @@
 #ifndef SYSCALL_H
 #define SYSCALL_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 /**
  * @brief Execute a system call
  *
@@ -9,4 +12,7 @@
 void
 do_syscall(int syscall_no);
 
+#ifdef __cplusplus
+}
+#endif
 #endif

--- a/sys/include/syscall/io.h
+++ b/sys/include/syscall/io.h
@@ -3,6 +3,9 @@
 
 struct thread;
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 /**
  * @brief Execute the open system call
  *
@@ -49,4 +52,7 @@ do_closedir(struct thread *current_thread);
 void
 do_readdir(struct thread *current_thread);
 
+#ifdef __cplusplus
+}
+#endif
 #endif

--- a/sys/include/syscall/mmap.h
+++ b/sys/include/syscall/mmap.h
@@ -3,6 +3,9 @@
 
 struct thread;
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 /**
  * @brief Execute the mmap system call
  *
@@ -17,4 +20,7 @@ do_mmap(struct thread *current_thread);
 void
 do_munmap(struct thread *current_thread);
 
+#ifdef __cplusplus
+}
+#endif
 #endif

--- a/sys/include/syscall/process.h
+++ b/sys/include/syscall/process.h
@@ -3,6 +3,9 @@
 
 struct thread;
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 /**
  * @brief   Execute the fork system call
  *
@@ -31,4 +34,7 @@ do_wait(struct thread *current_thread);
 void
 do_exit(struct thread *current_thread);
 
+#ifdef __cplusplus
+}
+#endif
 #endif

--- a/sys/include/term.h
+++ b/sys/include/term.h
@@ -1,6 +1,9 @@
 #ifndef KERNEL_TERM_H
 #define KERNEL_TERM_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 void
 term_init();
 
@@ -10,4 +13,7 @@ term_clear_screen();
 int
 term_write(const char *str);
 
+#ifdef __cplusplus
+}
+#endif
 #endif

--- a/sys/include/thread.h
+++ b/sys/include/thread.h
@@ -64,6 +64,9 @@ struct thread {
     struct process *process;
 };
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 /**
  * @brief Create a new thread
  *
@@ -127,4 +130,7 @@ thread_switch_and_return(struct thread *thread);
 void
 thread_save_state(struct thread *thread, struct isr_frame *irq_frame);
 
+#ifdef __cplusplus
+}
+#endif
 #endif

--- a/sys/include/tss.h
+++ b/sys/include/tss.h
@@ -35,6 +35,9 @@ struct tss {
     uint32_t iopb;
 } __attribute__((packed));
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 /**
  * @brief Initialize the TSS structure
  *
@@ -50,4 +53,7 @@ tss_init();
 void
 tss_load(int tss_segment);
 
+#ifdef __cplusplus
+}
+#endif
 #endif

--- a/sys/include/userio.h
+++ b/sys/include/userio.h
@@ -5,6 +5,9 @@
 
 struct thread;
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 /**
  * @brief Get an item from a thread's stack
  *
@@ -41,4 +44,7 @@ int
 thread_copy_to_user(
     struct thread *thread, void *user_buf, void *kernel_buf, size_t size);
 
+#ifdef __cplusplus
+}
+#endif
 #endif

--- a/sys/include/vfs.h
+++ b/sys/include/vfs.h
@@ -9,6 +9,9 @@
 struct block;
 struct dir_entry;
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 /**
  * @brief Initialize Virtual File System
  *
@@ -113,4 +116,7 @@ vfs_readdir(int fd, struct dir_entry *entry);
 int
 vfs_mkdir(const char *path);
 
+#ifdef __cplusplus
+}
+#endif
 #endif

--- a/sys/include/vm.h
+++ b/sys/include/vm.h
@@ -52,6 +52,9 @@ struct vm_area {
     page_dir_t page_directory;
 };
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 /**
  * @brief Initialize the kernel's vm_area
  *
@@ -216,4 +219,7 @@ vm_area_map_pages_to(
     struct vm_area *vm_area, void *virt, void *phys, void *phys_end,
     uint8_t flags);
 
+#ifdef __cplusplus
+}
+#endif
 #endif


### PR DESCRIPTION
## Summary
- wrap the function declarations in sys/include headers with `extern "C"` guards so they can be included from C++

## Testing
- not run (header-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d1db121590832cb7f4a05534e66e71