### PR TITLE
Declare zero-argument functions with void

### DIFF
--- a/bin/cat/src/cat.c
+++ b/bin/cat/src/cat.c
@@ -5,7 +5,7 @@
 #define BUF_SIZE 4096
 
 static void
-print_help()
+print_help(void)
 {
     printf("Usage: cat {FILE}\n");
     printf("Concatenate FILE(s) to standard output.\n");

--- a/bin/init/src/init.c
+++ b/bin/init/src/init.c
@@ -4,7 +4,7 @@
 #include "unistd.h"
 
 int
-main()
+main(void)
 {
     while (1) {
         pid_t pid = fork();

--- a/bin/ls/src/ls.c
+++ b/bin/ls/src/ls.c
@@ -4,7 +4,7 @@
 #include "unistd.h"
 
 static void
-print_help()
+print_help(void)
 {
     printf("Usage: /bin/ls {DIRECTORY}\n");
     printf("List information about files and directories\n");

--- a/bin/sh/src/sh.c
+++ b/bin/sh/src/sh.c
@@ -13,14 +13,14 @@ char program_name[MAX_LINE_LENGTH] = {0};
 char *program_args[MAX_PROGRAM_ARGS] = {0};
 
 static void
-sh_help()
+sh_help(void)
 {
     printf("Usage sh:\n");
     printf("Latte interactive shell\n");
 }
 
 static int
-sh_init()
+sh_init(void)
 {
     // Initial current working directory
     strcpy(CWD, "/");
@@ -29,7 +29,7 @@ sh_init()
 }
 
 static int
-sh_reset_input()
+sh_reset_input(void)
 {
     memset(input_line, 0, MAX_LINE_LENGTH);
     memset(program_name, 0, MAX_LINE_LENGTH);
@@ -39,7 +39,7 @@ sh_reset_input()
 }
 
 static inline void
-sh_prompt()
+sh_prompt(void)
 {
     printf("sh:%s> ", CWD);
 }

--- a/include/unistd.h
+++ b/include/unistd.h
@@ -19,7 +19,7 @@ int
 write(int fd, const char *ptr, size_t count);
 
 pid_t
-fork();
+fork(void);
 
 int
 execv(const char *path, char *const *argv);

--- a/lib/libc/src/entry.c
+++ b/lib/libc/src/entry.c
@@ -7,7 +7,7 @@ int argc;
 char **argv;
 
 void
-program_entry()
+program_entry(void)
 {
     int res = main(argc, argv);
 

--- a/lib/libc/src/init.c
+++ b/lib/libc/src/init.c
@@ -5,7 +5,7 @@ extern int stdout;
 extern int stderr;
 
 void
-libc_init()
+libc_init(void)
 {
     stdin = open("/dev/console", "r");
     stdout = open("/dev/console", "w");

--- a/lib/libc/src/sys/mmap/mmap.c
+++ b/lib/libc/src/sys/mmap/mmap.c
@@ -5,5 +5,5 @@
 void *
 mmap(size_t size)
 {
-    return do_syscall1(MMAP_SYSCALL_NO, size);
+    return (void *)do_syscall1(MMAP_SYSCALL_NO, size);
 }

--- a/lib/libc/src/unistd/fork.c
+++ b/lib/libc/src/unistd/fork.c
@@ -3,7 +3,7 @@
 #include "syscall.h"
 
 pid_t
-fork()
+fork(void)
 {
     return do_syscall0(FORK_SYSCALL_NO);
 }

--- a/sys/boot/boot.c
+++ b/sys/boot/boot.c
@@ -16,7 +16,7 @@
 #define to_paddr(addr)           ((void *)((uint32_t)addr - KERNEL_HIGHER_HALF_START))
 
 extern void
-boot_enable_paging();
+boot_enable_paging(void);
 
 extern void
 boot_load_page_directory(uint32_t *page_dir);
@@ -56,7 +56,7 @@ init_page_table(uint32_t *page_table, uint32_t page_tbl_offset, uint8_t flags)
  *
  */
 __attribute__((section(".boot.text"))) static void
-init_kernel_page_tables()
+init_kernel_page_tables(void)
 {
     for (int i = 0; i < PAGE_DIRECTORY_ENTRIES - KERNEL_DIR_ENTRIES; i++) {
         uint32_t tbl_offset = i * PAGE_TABLE_ENTRIES * PAGE_SIZE;
@@ -71,7 +71,7 @@ init_kernel_page_tables()
  *
  */
 __attribute__((section(".boot.text"))) static void
-map_kernel_directory()
+map_kernel_directory(void)
 {
 
     /* kernel_page_directory is located in high memory (e.g above 0xC0100000).
@@ -106,7 +106,7 @@ map_kernel_directory()
  *
  */
 __attribute__((section(".boot.text"))) static void
-setup_kernel_memory_map()
+setup_kernel_memory_map(void)
 {
     init_kernel_page_tables();
     map_kernel_directory();
@@ -121,7 +121,7 @@ setup_kernel_memory_map()
  *
  */
 __attribute__((section(".boot.text"))) void
-early_init()
+early_init(void)
 {
     setup_kernel_memory_map();
     boot_load_page_directory(to_paddr(kernel_page_directory));
@@ -134,7 +134,7 @@ early_init()
  * Unmap low memory and setup a GDT
  */
 void
-late_init()
+late_init(void)
 {
     paging_flush_tlb();
     gdt_init();

--- a/sys/cpu/cpu.c
+++ b/sys/cpu/cpu.c
@@ -25,13 +25,13 @@
 #define ICW4_SFNM       0x10 /* Special fully nested (not) */
 
 static inline void
-io_wait()
+io_wait(void)
 {
     outb(0x80, 0);
 }
 
 static int
-remap_pic()
+remap_pic(void)
 {
     printk("Remap PIC to 0x20\n");
 
@@ -74,7 +74,7 @@ remap_pic()
 }
 
 int
-cpu_init()
+cpu_init(void)
 {
     remap_pic();
 

--- a/sys/dev/bus.c
+++ b/sys/dev/bus.c
@@ -54,7 +54,7 @@ bus_probe_devices(const struct bus *bus)
 }
 
 int
-bus_init()
+bus_init(void)
 {
     platform_bus_init();
     platform_add_devices();
@@ -76,7 +76,7 @@ bus_register(struct bus *bus)
 }
 
 int
-bus_match()
+bus_match(void)
 {
     for_each_in_list(const struct bus *, bus_list, list, bus)
     {
@@ -87,7 +87,7 @@ bus_match()
 }
 
 int
-bus_probe()
+bus_probe(void)
 {
     for_each_in_list(const struct bus *, bus_list, list, bus)
     {

--- a/sys/dev/platform/platform_device.c
+++ b/sys/dev/platform/platform_device.c
@@ -76,7 +76,7 @@ err_exit:
 }
 
 int
-platform_bus_init()
+platform_bus_init(void)
 {
     int res = bus_register(&platform_bus);
     if (res < 0) {
@@ -87,13 +87,13 @@ platform_bus_init()
 }
 
 struct bus *
-platform_bus_get_bus()
+platform_bus_get_bus(void)
 {
     return &platform_bus;
 }
 
 int
-platform_add_devices()
+platform_add_devices(void)
 {
     struct platform_device *pdevices[STATIC_PLATFORM_DEVICE_COUNT];
     /* ATA0 Drive 0 */

--- a/sys/driver/driver.c
+++ b/sys/driver/driver.c
@@ -13,7 +13,7 @@
 static struct list_item *driver_list = NULL;
 
 int
-driver_init()
+driver_init(void)
 {
     platform_driver_init();
 

--- a/sys/driver/platform/ata/ata.c
+++ b/sys/driver/platform/ata/ata.c
@@ -16,7 +16,7 @@ struct platform_driver ata_pdev = {
     .driver = {.name = "ata", .compat = "ata"}, .probe = ata_probe};
 
 int
-ata_drv_init()
+ata_drv_init(void)
 {
     platform_driver_register(&ata_pdev);
 

--- a/sys/driver/platform/console/console.c
+++ b/sys/driver/platform/console/console.c
@@ -105,7 +105,7 @@ console_input_recv_callback(struct input_device *idev, struct input_event event)
 }
 
 int
-console_drv_init()
+console_drv_init(void)
 {
     platform_driver_register(&console_drv);
 

--- a/sys/driver/platform/devfs/devfs.c
+++ b/sys/driver/platform/devfs/devfs.c
@@ -15,7 +15,7 @@ struct platform_driver devfs_pdev = {
     .driver = {.name = "devfs", .compat = "devfs"}, .probe = devfs_probe};
 
 int
-devfs_drv_init()
+devfs_drv_init(void)
 {
     platform_driver_register(&devfs_pdev);
 

--- a/sys/driver/platform/kbd/kbd.c
+++ b/sys/driver/platform/kbd/kbd.c
@@ -34,7 +34,7 @@ scancode_to_keycode(uint8_t scancode)
 }
 
 static void
-kbd_interrupt_handler()
+kbd_interrupt_handler(void)
 {
     uint8_t scancode = ps2_read_data();
     ps2_read_data();
@@ -59,7 +59,7 @@ kbd_interrupt_handler()
 }
 
 static int
-kbd_ps2_init()
+kbd_ps2_init(void)
 {
     /* Disable PS2 ports */
     ps2_write_cmd(PS2_CMD_DIS_PORT1);
@@ -113,7 +113,7 @@ kbd_ps2_init()
 }
 
 int
-kbd_drv_init()
+kbd_drv_init(void)
 {
     platform_driver_register(&kbd_drv);
 

--- a/sys/driver/platform/kbd/ps2.c
+++ b/sys/driver/platform/kbd/ps2.c
@@ -30,7 +30,7 @@ ps2_wait_for_input(uint8_t port)
  * @brief Wait for the PS2 output buffer to by full
  */
 static void
-ps2_wait_for_output()
+ps2_wait_for_output(void)
 {
     int i = 0;
     do {
@@ -57,7 +57,7 @@ ps2_write_data(uint8_t data)
 }
 
 uint8_t
-ps2_read_data()
+ps2_read_data(void)
 {
     ps2_wait_for_output();
     return insb(PS2_DATA_PORT);

--- a/sys/driver/platform/platform_driver.c
+++ b/sys/driver/platform/platform_driver.c
@@ -11,7 +11,7 @@
 #include <stddef.h>
 
 int
-platform_driver_init()
+platform_driver_init(void)
 {
     ata_drv_init();
     devfs_drv_init();

--- a/sys/driver/platform/vga/vga.c
+++ b/sys/driver/platform/vga/vga.c
@@ -31,7 +31,7 @@ vga_color(enum vga_color fg, enum vga_color bg)
 }
 
 int
-vga_drv_init()
+vga_drv_init(void)
 {
     platform_driver_register(&vga_drv);
 
@@ -102,7 +102,7 @@ vga_current_color(struct device *dev)
 }
 
 void
-vga_enable_cursor()
+vga_enable_cursor(void)
 {
     uint8_t cursor_start = 14;
     uint8_t cursor_end = 15;
@@ -115,7 +115,7 @@ vga_enable_cursor()
 }
 
 void
-vga_disable_cursor()
+vga_disable_cursor(void)
 {
     outb(0x3D4, 0x0A);
     outb(0x3D5, 0x20);

--- a/sys/fs/devfs/devfs.c
+++ b/sys/fs/devfs/devfs.c
@@ -309,7 +309,7 @@ err_reader_alloc:
 }
 
 struct filesystem *
-devfs_init()
+devfs_init(void)
 {
     struct filesystem *fs = kzalloc(sizeof(struct filesystem));
     if (!fs) {

--- a/sys/fs/ext2/ext2.c
+++ b/sys/fs/ext2/ext2.c
@@ -365,7 +365,7 @@ ext2_mkdir(void *fs_private, struct path *path)
 }
 
 struct filesystem *
-ext2_init()
+ext2_init(void)
 {
     struct filesystem *fs = kzalloc(sizeof(struct filesystem));
     if (!fs) {

--- a/sys/fs/ext2/ext2.c
+++ b/sys/fs/ext2/ext2.c
@@ -12,6 +12,7 @@
 #include "kernel.h"
 #include "libk/alloc.h"
 #include "libk/memory.h"
+#include "libk/print.h"
 #include "libk/string.h"
 #include "mountpoint.h"
 #include "path.h"

--- a/sys/fs/fat32/fat32.c
+++ b/sys/fs/fat32/fat32.c
@@ -1,7 +1,7 @@
 #include "fs/fat32.h"
 
 struct filesystem *
-fat32_init()
+fat32_init(void)
 {
     // TODO
     return 0;

--- a/sys/fs/fs.c
+++ b/sys/fs/fs.c
@@ -41,7 +41,7 @@ fs_insert_filesystem(struct filesystem *filesystem)
  *
  */
 static int
-fs_load()
+fs_load(void)
 {
     // fs_insert_filesystem(fat32_init());
     int res = fs_insert_filesystem(ext2_init());
@@ -58,7 +58,7 @@ fs_load()
 }
 
 int
-fs_init()
+fs_init(void)
 {
     return fs_load();
 }

--- a/sys/gdt/gdt.c
+++ b/sys/gdt/gdt.c
@@ -46,7 +46,7 @@ gdt_load(struct gdtr *gdtr);
  *
  */
 void
-gdt_fix_kernel_registers();
+gdt_fix_kernel_registers(void);
 
 /**
  * @brief Encode structure gdt as real gdt
@@ -99,7 +99,7 @@ gdt_structured_to_gdt(
 }
 
 void
-gdt_init()
+gdt_init(void)
 {
     memset(gdt, 0, sizeof(gdt));
     memset(&gdtr, 0, sizeof(struct gdtr));

--- a/sys/gdt/tss.c
+++ b/sys/gdt/tss.c
@@ -13,7 +13,7 @@ struct tss tss;
 extern struct vm_area kernel_vm_area;
 
 static void
-tss_map_esp()
+tss_map_esp(void)
 {
     size_t order = kalloc_size_to_order(TSS_STACK_SIZE);
     void *tss_stack = kalloc_get_phys_pages(order);
@@ -34,7 +34,7 @@ tss_map_esp()
 }
 
 void
-tss_init()
+tss_init(void)
 {
     printk("Init TSS at %d\n", (int)&tss);
 

--- a/sys/include/bus.h
+++ b/sys/include/bus.h
@@ -24,15 +24,15 @@ struct bus {
 };
 
 int
-bus_init();
+bus_init(void);
 
 int
 bus_register(struct bus *bus);
 
 int
-bus_match();
+bus_match(void);
 
 int
-bus_probe();
+bus_probe(void);
 
 #endif

--- a/sys/include/cpu.h
+++ b/sys/include/cpu.h
@@ -2,6 +2,6 @@
 #define CPU_H
 
 int
-cpu_init();
+cpu_init(void);
 
 #endif

--- a/sys/include/dev/platform_device.h
+++ b/sys/include/dev/platform_device.h
@@ -21,13 +21,13 @@ struct platform_device {
 };
 
 int
-platform_bus_init();
+platform_bus_init(void);
 
 struct bus *
-platform_bus_get_bus();
+platform_bus_get_bus(void);
 
 int
-platform_add_devices();
+platform_add_devices(void);
 
 int
 platform_match(struct device *dev, struct device_driver *drv);

--- a/sys/include/driver.h
+++ b/sys/include/driver.h
@@ -26,7 +26,7 @@ struct file_operations {
 };
 
 int
-driver_init();
+driver_init(void);
 
 int
 driver_register(struct device_driver *driver);

--- a/sys/include/driver/platform/ata.h
+++ b/sys/include/driver/platform/ata.h
@@ -49,7 +49,7 @@ struct ata_private {
 };
 
 int
-ata_drv_init();
+ata_drv_init(void);
 
 int
 ata_probe(struct platform_device *pdev);

--- a/sys/include/driver/platform/console.h
+++ b/sys/include/driver/platform/console.h
@@ -30,7 +30,7 @@ struct console_private {
 };
 
 int
-console_drv_init();
+console_drv_init(void);
 
 int
 console_probe(struct platform_device *dev);

--- a/sys/include/driver/platform/devfs.h
+++ b/sys/include/driver/platform/devfs.h
@@ -7,7 +7,7 @@ struct device;
 struct platform_device;
 
 int
-devfs_drv_init();
+devfs_drv_init(void);
 
 int
 devfs_probe(struct platform_device *pdev);

--- a/sys/include/driver/platform/kbd.h
+++ b/sys/include/driver/platform/kbd.h
@@ -16,7 +16,7 @@ struct kbd_private {
 };
 
 int
-kbd_drv_init();
+kbd_drv_init(void);
 
 int
 kbd_probe(struct platform_device *dev);

--- a/sys/include/driver/platform/kbd/ps2.h
+++ b/sys/include/driver/platform/kbd/ps2.h
@@ -45,6 +45,6 @@ void
 ps2_write_data(uint8_t data);
 
 uint8_t
-ps2_read_data();
+ps2_read_data(void);
 
 #endif

--- a/sys/include/driver/platform/vga.h
+++ b/sys/include/driver/platform/vga.h
@@ -37,7 +37,7 @@ struct vga_private {
 };
 
 int
-vga_drv_init();
+vga_drv_init(void);
 
 int
 vga_probe(struct platform_device *pdev);
@@ -61,10 +61,10 @@ uint8_t
 vga_current_color(struct device *dev);
 
 void
-vga_enable_cursor();
+vga_enable_cursor(void);
 
 void
-vga_disable_cursor();
+vga_disable_cursor(void);
 
 void
 vga_set_cursor(struct device *dev, uint16_t row, uint16_t col);

--- a/sys/include/driver/platform_driver.h
+++ b/sys/include/driver/platform_driver.h
@@ -14,7 +14,7 @@ struct platform_driver {
 };
 
 int
-platform_driver_init();
+platform_driver_init(void);
 
 int
 platform_driver_register(struct platform_driver *driver);

--- a/sys/include/fs.h
+++ b/sys/include/fs.h
@@ -88,7 +88,7 @@ struct filesystem {
  * @return int  Status code
  */
 int
-fs_init();
+fs_init(void);
 
 /**
  * @brief Resolve a filesystem to a mountpoint

--- a/sys/include/fs/devfs.h
+++ b/sys/include/fs/devfs.h
@@ -11,7 +11,7 @@ struct filesystem;
  * @return struct filesystem*   Pointer to the filesystem
  */
 struct filesystem *
-devfs_init();
+devfs_init(void);
 
 /**
  * @brief Add a new node to devfs

--- a/sys/include/fs/ext2.h
+++ b/sys/include/fs/ext2.h
@@ -9,6 +9,6 @@ struct filesystem;
  * @return struct filesystem* Pointer to filesystem
  */
 struct filesystem *
-ext2_init();
+ext2_init(void);
 
 #endif

--- a/sys/include/fs/fat32.h
+++ b/sys/include/fs/fat32.h
@@ -4,6 +4,6 @@
 #include "fs.h"
 
 struct filesystem *
-fat32_init();
+fat32_init(void);
 
 #endif

--- a/sys/include/gdt.h
+++ b/sys/include/gdt.h
@@ -33,19 +33,19 @@ struct gdt {
  *
  */
 void
-gdt_init();
+gdt_init(void);
 
 /**
  * @brief Sets the segment registers to the kernel data segment
  *
  */
 void
-gdt_set_kernel_data_segment();
+gdt_set_kernel_data_segment(void);
 
 /**
  * @brief Sets the segment registers to the user data segment
  *
  */
 void
-gdt_set_user_data_segment();
+gdt_set_user_data_segment(void);
 #endif

--- a/sys/include/idt.h
+++ b/sys/include/idt.h
@@ -41,6 +41,6 @@ struct idt_entry {
  *
  */
 void
-idt_init();
+idt_init(void);
 
 #endif

--- a/sys/include/irq.h
+++ b/sys/include/irq.h
@@ -8,13 +8,13 @@
  *
  */
 void
-irq_init();
+irq_init(void);
 
 /**
  * @brief Interrupt handler prototype definition
  *
  */
-typedef void (*IRQ_HANDLER)();
+typedef void (*IRQ_HANDLER)(void);
 
 /**
  * @brief Register an interrupt handler
@@ -40,13 +40,13 @@ do_irq(int interrupt_no);
  *
  */
 void
-enable_interrupts();
+enable_interrupts(void);
 
 /**
  * @brief Disable Interrupts
  *
  */
 void
-disable_interrupts();
+disable_interrupts(void);
 
 #endif

--- a/sys/include/kernel.h
+++ b/sys/include/kernel.h
@@ -9,6 +9,6 @@ void
 panic(const char *str);
 
 void
-switch_to_kernel_vm_area();
+switch_to_kernel_vm_area(void);
 
 #endif

--- a/sys/include/libk/alloc.h
+++ b/sys/include/libk/alloc.h
@@ -8,7 +8,7 @@
  *
  */
 void
-libk_alloc_init();
+libk_alloc_init(void);
 
 /**
  * @brief   Allocate a block of memory
@@ -40,7 +40,7 @@ vzalloc(size_t size);
  *
  */
 void
-vfree();
+vfree(void *ptr);
 
 /**
  * @brief   Allocate a block of memory

--- a/sys/include/msgbuf.h
+++ b/sys/include/msgbuf.h
@@ -20,6 +20,6 @@ int
 msgbuf_add_output_fd(int fd);
 
 int
-msgbuf_flush();
+msgbuf_flush(void);
 
 #endif

--- a/sys/include/paging.h
+++ b/sys/include/paging.h
@@ -33,7 +33,7 @@
  *
  */
 void
-paging_enable_paging();
+paging_enable_paging(void);
 
 /**
  * @brief Load a new page directory
@@ -48,7 +48,7 @@ paging_load_page_directory(page_dir_t page_dir);
  *
  */
 void
-paging_flush_tlb();
+paging_flush_tlb(void);
 
 /**
  * @brief   Copy kernel page directory entries to user page directory

--- a/sys/include/process.h
+++ b/sys/include/process.h
@@ -112,7 +112,7 @@ struct process {
  * @return uint32_t
  */
 uint32_t
-process_next_pid();
+process_next_pid(void);
 
 /**
  * @brief   Free all threads of a process

--- a/sys/include/sched.h
+++ b/sys/include/sched.h
@@ -45,20 +45,20 @@ sched_unblock_thread(struct thread *thread);
  * @return struct thread*
  */
 struct thread *
-sched_get_current();
+sched_get_current(void);
 
 /**
  * @brief Schedule the first thread to run
  *
  */
 void
-schedule_first_thread();
+schedule_first_thread(void);
 
 /**
  * @brief Schedule a new thread to run
  *
  */
 void
-schedule();
+schedule(void);
 
 #endif

--- a/sys/include/term.h
+++ b/sys/include/term.h
@@ -2,10 +2,10 @@
 #define KERNEL_TERM_H
 
 void
-term_init();
+term_init(void);
 
 void
-term_clear_screen();
+term_clear_screen(void);
 
 int
 term_write(const char *str);

--- a/sys/include/tss.h
+++ b/sys/include/tss.h
@@ -40,7 +40,7 @@ struct tss {
  *
  */
 void
-tss_init();
+tss_init(void);
 
 /**
  * @brief Load the TSS segment

--- a/sys/include/vfs.h
+++ b/sys/include/vfs.h
@@ -15,7 +15,7 @@ struct dir_entry;
  * @return int  Status code
  */
 int
-vfs_init();
+vfs_init(void);
 
 /**
  * @brief Mount a partition

--- a/sys/init/main.c
+++ b/sys/init/main.c
@@ -41,7 +41,7 @@ panic(const char *str)
  *
  */
 void
-switch_to_kernel_vm_area()
+switch_to_kernel_vm_area(void)
 {
     gdt_set_kernel_data_segment();
     vm_area_switch_map(&kernel_vm_area);
@@ -84,7 +84,7 @@ kernel_early_init(unsigned long magic)
  *
  */
 void
-kernel_late_init()
+kernel_late_init(void)
 {
     bus_init();
 

--- a/sys/init/msgbuf.c
+++ b/sys/init/msgbuf.c
@@ -22,7 +22,7 @@ static const char buffer_overflow_msg[] = "Kernel Message Buffer Overflow!";
  *
  */
 static void
-msgbuf_buffer_overflow()
+msgbuf_buffer_overflow(void)
 {
     size_t msglen = strlen(buffer_overflow_msg);
     char *dest = message_buffer + (MSGBUF_BUFFER_SIZE - msglen);
@@ -87,7 +87,7 @@ msgbuf_add_output_fd(int fd)
 }
 
 int
-msgbuf_flush()
+msgbuf_flush(void)
 {
     if (msgbuf_len > 0) {
         msgbuf_write_to_fds(message_buffer);

--- a/sys/init/term.c
+++ b/sys/init/term.c
@@ -29,7 +29,7 @@ set_char(uint16_t row, uint16_t col, char c)
 }
 
 static void
-term_scroll()
+term_scroll(void)
 {
     uint16_t *fb = VGA_FRAMEBUFFER;
 
@@ -46,7 +46,7 @@ term_scroll()
 }
 
 static void
-term_newline()
+term_newline(void)
 {
     if (row == VGA_HEIGHT) {
         term_scroll();
@@ -75,13 +75,13 @@ term_put_char(char c)
 }
 
 void
-term_init()
+term_init(void)
 {
     term_clear_screen();
 }
 
 void
-term_clear_screen()
+term_clear_screen(void)
 {
     for (size_t y = 0; y < VGA_HEIGHT; y++) {
         for (size_t x = 0; x < VGA_WIDTH; x++) {

--- a/sys/irq/idt.c
+++ b/sys/irq/idt.c
@@ -48,7 +48,7 @@ idt_set_entry(int interrupt_no, void *isr)
 }
 
 void
-idt_init()
+idt_init(void)
 {
     printk("Init IDT at %d\n", (int)int_desc_tbl);
 

--- a/sys/irq/irq.c
+++ b/sys/irq/irq.c
@@ -8,7 +8,7 @@
 IRQ_HANDLER irq_handlers[LATTE_TOTAL_IDT_ENTRIES] = {0};
 
 void
-irq_init()
+irq_init(void)
 {
     idt_init();
 }

--- a/sys/libk/alloc.c
+++ b/sys/libk/alloc.c
@@ -93,7 +93,7 @@ err_out:
 }
 
 void
-libk_alloc_init()
+libk_alloc_init(void)
 {
     for (int i = 0; i < KMALLOC_SLAB_CACHES; i++) {
         int cache_size = KMALLOC_IDX_TO_CACHE_SIZE(i);

--- a/sys/process/process.c
+++ b/sys/process/process.c
@@ -20,7 +20,7 @@ static struct list_item *process_list = NULL;
 static uint32_t next_pid = 1;
 
 uint32_t
-process_next_pid()
+process_next_pid(void)
 {
     return next_pid++;
 }

--- a/sys/sched/sched.c
+++ b/sys/sched/sched.c
@@ -51,13 +51,13 @@ sched_unblock_thread(struct thread *thread)
 }
 
 struct thread *
-sched_get_current()
+sched_get_current(void)
 {
     return current_thread;
 }
 
 void
-schedule_first_thread()
+schedule_first_thread(void)
 {
     current_thread = queue_dequeue(&ready_queue);
     if (!current_thread) {
@@ -70,7 +70,7 @@ schedule_first_thread()
 }
 
 void
-schedule()
+schedule(void)
 {
     if (current_thread) {
         // Enqueue currently running thread

--- a/sys/syscall/syscall.c
+++ b/sys/syscall/syscall.c
@@ -9,7 +9,7 @@
 #include "syscall/process.h"
 #include "thread.h"
 
-typedef void (*syscall_t)(void);
+typedef void (*syscall_t)(struct thread *);
 
 static syscall_t syscalls[] = {
     do_open,  do_close, do_read, do_write,   do_mmap,     do_munmap, do_fork,

--- a/sys/syscall/syscall.c
+++ b/sys/syscall/syscall.c
@@ -9,7 +9,7 @@
 #include "syscall/process.h"
 #include "thread.h"
 
-typedef void (*syscall_t)();
+typedef void (*syscall_t)(void);
 
 static syscall_t syscalls[] = {
     do_open,  do_close, do_read, do_write,   do_mmap,     do_munmap, do_fork,

--- a/sys/thread/thread.c
+++ b/sys/thread/thread.c
@@ -26,7 +26,7 @@ static uint32_t next_tid = 1;
  * @return uint32_t
  */
 static inline uint32_t
-get_next_tid()
+get_next_tid(void)
 {
     return next_tid++;
 }

--- a/sys/vfs/vfs.c
+++ b/sys/vfs/vfs.c
@@ -71,7 +71,7 @@ vfs_find_and_mount(const char *mount_path, bool (*predicate)(struct block *))
 }
 
 int
-vfs_init()
+vfs_init(void)
 {
     int res = vfs_find_and_mount("/", is_boot_block);
     if (res < 0) {

--- a/test/lib/libc/test_strtok.c
+++ b/test/lib/libc/test_strtok.c
@@ -21,7 +21,7 @@ struct test_case test_cases[] = {
     {.name = 0, .test_function = 0, .setup_fixture = 0, .teardown_fixture = 0}};
 
 int
-main()
+main(void)
 {
     test_init();
     run_tests(test_cases);

--- a/test/sys/fs/test_path.c
+++ b/test/sys/fs/test_path.c
@@ -117,7 +117,7 @@ struct test_case test_cases[] = {
     {.name = 0, .test_function = 0, .setup_fixture = 0, .teardown_fixture = 0}};
 
 int
-main()
+main(void)
 {
     test_init();
     run_tests(test_cases);

--- a/test/sys/libk/test_memory.c
+++ b/test/sys/libk/test_memory.c
@@ -80,7 +80,7 @@ struct test_case test_cases[] = {
     {.name = 0, .test_function = 0, .setup_fixture = 0, .teardown_fixture = 0}};
 
 int
-main()
+main(void)
 {
     test_init();
     run_tests(test_cases);

--- a/test/sys/libk/test_string.c
+++ b/test/sys/libk/test_string.c
@@ -188,7 +188,7 @@ struct test_case test_cases[] = {
     {.name = 0, .test_function = 0, .setup_fixture = 0, .teardown_fixture = 0}};
 
 int
-main()
+main(void)
 {
     test_init();
     run_tests(test_cases);

--- a/test/sys/mem/test_heap.c
+++ b/test/sys/mem/test_heap.c
@@ -11,7 +11,7 @@
 static struct heap heap;
 
 void *
-setup_fixture()
+setup_fixture(void)
 {
     void *heap_addr = malloc(HEAP_SIZE);
     heap_init(&heap, heap_addr);
@@ -19,7 +19,7 @@ setup_fixture()
 }
 
 void
-teardown_fixture()
+teardown_fixture(void)
 {
     free(heap.saddr);
 }
@@ -126,7 +126,7 @@ struct test_case test_cases[] = {
     {.name = 0, .test_function = 0, .setup_fixture = 0, .teardown_fixture = 0}};
 
 int
-main()
+main(void)
 {
     test_init();
     run_tests(test_cases);

--- a/test/test.c
+++ b/test/test.c
@@ -6,7 +6,7 @@
 struct test_case sentinal;
 
 void
-test_init()
+test_init(void)
 {
     memset(&sentinal, 0, sizeof(struct test_case));
 }

--- a/test/test.h
+++ b/test/test.h
@@ -75,7 +75,7 @@ struct test_case {
     }
 
 void
-test_init();
+test_init(void);
 
 void
 run_tests(const struct test_case *tests);


### PR DESCRIPTION
## Summary
- declare zero-argument kernel interfaces with explicit `void` parameter lists to prevent unintended variadic calls
- update user-space libraries and utilities so helper functions and entry points also use explicit `void`

## Testing
- make *(fails: i686-elf-gcc missing in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ed9a7590f0832cb1c13f6e5e57fb30